### PR TITLE
Fix cast bar module path

### DIFF
--- a/AzCastBar/AzCastBar.toc
+++ b/AzCastBar/AzCastBar.toc
@@ -22,8 +22,8 @@ Modules\acb_Auras\acbAuras_TWW.lua
 Modules\acb_BattleGround\acbBattleGrounds.lua
 
 ## Castbar
-## Modules\acb_Castbar\acbCast.lua
-Modules\acb_Castbar\acbCast_TWW.lua
+## Modules\acb_CastBar\acbCast.lua
+Modules\acb_CastBar\acbCast_TWW.lua
 
 ## Cooldowns
 Modules\acb_Cooldowns\acbCooldowns.lua


### PR DESCRIPTION
## Summary
- fix path to `acb_CastBar` folder in AzCastBar.toc

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68753e998d30832e93624eed47ff0c06