### PR TITLE
Fix empower cast nil delayText

### DIFF
--- a/AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua
+++ b/AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua
@@ -297,6 +297,9 @@ function events:UNIT_SPELLCAST_EMPOWER_START(event, unit, lineID, spellID)
         self.icon:SetTexture(texture)
         self.name:SetText((spell or "") .. " (Empowering)")
 
+        self.castDelay = 0
+        self.delayText = ""
+
         self:ResetAndShow(castTime, 1)
 end
 


### PR DESCRIPTION
## Summary
- prevent `delayText` nil error when an empower cast starts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875a8e8c6cc832e905c87597332a402