### PR TITLE
Fix color picker alpha retrieval

### DIFF
--- a/AzCastBarOptions/Libs/AzOptionsFactory.lua
+++ b/AzCastBarOptions/Libs/AzOptionsFactory.lua
@@ -284,8 +284,8 @@ local r, g, b, a
 if (prevVal and prevVal.GetRGBA) then
 	r, g, b, a = prevVal:GetRGBA()
 	else
-		r, g, b = CPF:GetColorRGB()
-		a = CPF.opacity or .2
+       r, g, b = CPF:GetColorRGB()
+       a = 1 - (CPF.opacity or 0)
 		end
 
 		-- Update frame only if it's still showing this option
@@ -362,15 +362,16 @@ local function ColorButton_OnClick(self,button)
 
 	-- new functionality for color picker
 
-        CPF:SetupColorPickerAndShow({
 
-                r = r,
+       CPF:SetupColorPickerAndShow({
 
-                g = g,
+               r = r,
 
-                b = b,
+               g = g,
 
-                opacity = a,
+               b = b,
+
+               opacity = opacity,
 
                 hasOpacity = true,
 


### PR DESCRIPTION
## Summary
- fix retrieving the alpha value from the color picker
- pass the proper alpha to `SetupColorPickerAndShow`

## Testing
- `luac -p AzCastBarOptions/Libs/AzOptionsFactory.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6877052a38c0832e847189943d0c7805