### PR TITLE
Fix missing end in Mirror module

### DIFF
--- a/AzCastBar/Modules/acb_Mirror/acbMirror.lua
+++ b/AzCastBar/Modules/acb_Mirror/acbMirror.lua
@@ -136,12 +136,13 @@ function plugin:OnConfigChanged(cfg)
 					MirrorTimerContainer:RegisterEvent("MIRROR_TIMER_START")
 					MirrorTimerContainer:RegisterEvent("MIRROR_TIMER_STOP")
 					MirrorTimerContainer:RegisterEvent("MIRROR_TIMER_PAUSE")
-				else
-					for i = 1, 3 do
-						_G["MirrorTimer"..i]:RegisterEvent("MIRROR_TIMER_PAUSE")
-						_G["MirrorTimer"..i]:RegisterEvent("MIRROR_TIMER_STOP")
-                end
-        end
+                                else
+                                        for i = 1, 3 do
+                                                _G["MirrorTimer"..i]:RegisterEvent("MIRROR_TIMER_PAUSE")
+                                                _G["MirrorTimer"..i]:RegisterEvent("MIRROR_TIMER_STOP")
+                                        end
+                                end
+                        end
 
        -- Update visuals for all mirror bars
        for _, bar in ipairs(self.bars) do


### PR DESCRIPTION
## Summary
- fix missing `end` in `OnConfigChanged`

## Testing
- `luac` unavailable, unable to run Lua syntax check

------
https://chatgpt.com/codex/tasks/task_e_6878f48494b8832e9adb371b8e62da31