### PR TITLE
Fix nil threat bar color

### DIFF
--- a/AzCastBar/Modules/acb_Threat/acbThreat.lua
+++ b/AzCastBar/Modules/acb_Threat/acbThreat.lua
@@ -2,10 +2,11 @@ local GetTime = GetTime;
 
 -- Extra Options
 local extraOptions = {
-	{
-		[0] = "Options",
-		{ type = "Slider", var = "threshold", default = 75, label = "Display Threshold", min = 0, max = 100, step = 1 },
-	},
+        {
+                [0] = "Options",
+                { type = "Slider", var = "threshold", default = 75, label = "Display Threshold", min = 0, max = 100, step = 1 },
+                { type = "Color", var = "colNormal", default = { 0.4, 0.6, 0.8 }, label = "Threat Bar Color" },
+        },
 };
 
 -- Plugin


### PR DESCRIPTION
## Summary
- add missing color configuration to the threat bar

## Testing
- `lua -v` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6878f55fee38832e91f1c16eb4adf197