### PR TITLE
Fix cast bar fade-out referencing global config

### DIFF
--- a/AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua
+++ b/AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua
@@ -418,10 +418,10 @@ local function StartFadeOut(self)
         end
 
        -- Apply updated visual settings immediately
-       self:SetAlpha(cfg.alpha)
-       self.status:SetStatusBarColor(unpack(cfg.colNormal))
+       self:SetAlpha(self.cfg.alpha)
+       self.status:SetStatusBarColor(unpack(self.cfg.colNormal))
        if (self.safezone) then
-               self.safezone:SetColorTexture(unpack(cfg.colSafezone))
+               self.safezone:SetColorTexture(unpack(self.cfg.colSafezone))
        end
 end
 


### PR DESCRIPTION
## Summary
- fix StartFadeOut to use the bar's config rather than a missing global

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878f66f1e4c832e9aa1ff070d4c6c0b