### PR TITLE
Fix backdrop none option

### DIFF
--- a/AzCastBar/acbCore.lua
+++ b/AzCastBar/acbCore.lua
@@ -350,8 +350,12 @@ if (type(plugin.options) == "table") then
 
 			-- Alpha + Backdrop
 			bar:SetAlpha(barCfg.alpha);
-			bar:SetBackdrop(backDrop);
-			bar:SetBackdropColor(unpack(barCfg.colBackdrop));
+                        if (not barCfg.bgFile) or (barCfg.bgFile == "Interface\None") or (barCfg.bgFile == "") then
+                                bar:SetBackdrop(nil);
+                        else
+                                bar:SetBackdrop(backDrop);
+                        end
+                        bar:SetBackdropColor(unpack(barCfg.colBackdrop));
 			--	bar:SetBackdropBorderColor(unpack(barCfg.colBackdropBorder));
 
 			-- StatusBar Texture -- This code will check if the texture set is valid, if not, it will be defaulted to the one set in "ACB_DefOptions"


### PR DESCRIPTION
## Summary
- selecting None for backdrop now hides the backdrop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878ff438cac832ea233f5f30763e144