### PR TITLE
Fix nil GetSpellInfo in cooldown plugin

### DIFF
--- a/AzCastBar/Modules/acb_Cooldowns/acbCooldowns.lua
+++ b/AzCastBar/Modules/acb_Cooldowns/acbCooldowns.lua
@@ -1,4 +1,7 @@
 local GetTime = GetTime;
+-- WoW 11.0 removed the global GetSpellInfo function, so fall back to the
+-- C_Spell API when the global does not exist.
+local GetSpellInfo = GetSpellInfo or (C_Spell and C_Spell.GetSpellInfo);
 
 -- Extra Options
 local extraOptions = {


### PR DESCRIPTION
## Summary
- prevent nil access to `GetSpellInfo` in cooldown plugin

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_688584afc67c832e822844eabd0b8d3a