### PR TITLE
Fix Revive Battle Pets cooldown display

### DIFF
--- a/AzCastBar/Modules/acb_Cooldowns/acbCooldowns.lua
+++ b/AzCastBar/Modules/acb_Cooldowns/acbCooldowns.lua
@@ -21,6 +21,9 @@ local timers = LibTableRecycler:New();
 local ignoredSpells = {}
 do
     local revivePet = GetSpellInfo(125439)
+    if type(revivePet) == "table" then
+        revivePet = revivePet.name
+    end
     if revivePet then
         ignoredSpells[revivePet] = true
     end


### PR DESCRIPTION
## Summary
- ensure `Revive Battle Pets` is excluded from cooldown tracking

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885865bab80832eaae4f37ddc00a4bb