### PR TITLE
Prevent empower tick builder from infinite looping

### DIFF
--- a/AzCastBar/EmpowerCastBar.lua
+++ b/AzCastBar/EmpowerCastBar.lua
@@ -83,6 +83,7 @@ local function buildTicks()
       if d == nil then break end
       stageDur[stageIndex] = d
       totalDur = totalDur + (d > 0 and d or 0)
+      if d <= 0 then break end
       stageIndex = stageIndex + 1
     end
     numStages = #stageDur


### PR DESCRIPTION
## Summary
- avoid infinite loop when fetching empower stage durations

## Testing
- `apt-get update` *(fails: repository 403)*
- `luac -p AzCastBar/EmpowerCastBar.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3661bf68c832ebab1a82ede66d25a