### PR TITLE
Guard against infinite empower stage loops

### DIFF
--- a/AzCastBar/EmpowerCastBar.lua
+++ b/AzCastBar/EmpowerCastBar.lua
@@ -39,6 +39,7 @@ local spellID    = nil
 local stageDur   = {}   -- per stage seconds
 local totalDur   = 0
 local elapsed    = 0
+local MAX_STAGES = 10 -- safety to avoid infinite loops
 
 -- WoW 11.0 removed the global GetSpellInfo function, so fall back to the
 -- C_Spell API when the global does not exist.
@@ -85,7 +86,7 @@ local function buildTicks()
   -- Fallback: query stage duration per index until API returns nil
   if not numStages then
     local stageIndex = 1
-    while true do
+    while stageIndex <= MAX_STAGES do
       local d = GetStageDuration(stageIndex)
       if d == nil then break end
       stageDur[stageIndex] = d

--- a/AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua
+++ b/AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua
@@ -42,6 +42,7 @@ local GetUnitEmpowerStageDuration = GetUnitEmpowerStageDuration or (C_CastingInf
 -- WoW 11.0 removed the global GetSpellInfo function, so fall back to the
 -- C_Spell API when the global does not exist.
 local GetSpellInfo = GetSpellInfo or (C_Spell and C_Spell.GetSpellInfo);
+local MAX_EMPOWER_STAGES = 10 -- safety cap
 
 -- Extra Options
 local extraOptions = {
@@ -150,7 +151,7 @@ local function BuildStageTicks(self)
        -- Fallback to querying per stage if needed
        if numStages == 0 then
                local i = 1
-               while true do
+               while i <= MAX_EMPOWER_STAGES do
                        local dur = GetUnitEmpowerStageDuration and GetUnitEmpowerStageDuration(self.unit, i)
                        if (dur == nil or dur <= 0) and C_Spell and C_Spell.GetSpellEmpowerStageDuration then
                                dur = C_Spell.GetSpellEmpowerStageDuration(self.empSpellID, i)


### PR DESCRIPTION
## Summary
- limit empower stage parsing to at most ten stages
- prevent indefinite loops when querying empower stage durations

## Testing
- ⚠️ `lua -p AzCastBar/EmpowerCastBar.lua AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b36de0984c832ebad384aeb520d5b0