### PR TITLE
Fix empower stage detection using updated spell API

### DIFF
--- a/AzCastBar/EmpowerCastBar.lua
+++ b/AzCastBar/EmpowerCastBar.lua
@@ -44,17 +44,17 @@ local MAX_STAGES = 10 -- safety to avoid infinite loops
 -- WoW 11.0 removed the global GetSpellInfo function, so fall back to the
 -- C_Spell API when the global does not exist.
 local GetSpellInfo = GetSpellInfo or (C_Spell and C_Spell.GetSpellInfo);
+local C_Spell = C_Spell;
 local C_CastingInfo = C_CastingInfo;
 
 -- Helper: obtain empower stage duration regardless of API changes
 local function GetStageDuration(stageIndex)
-  -- Newer client builds expose empower data through C_CastingInfo
-  if C_CastingInfo and C_CastingInfo.GetEmpowerStageDuration then
-    return C_CastingInfo.GetEmpowerStageDuration(unit, stageIndex)
-  elseif GetUnitEmpowerStageDuration then
+  if GetUnitEmpowerStageDuration then
     return GetUnitEmpowerStageDuration(unit, stageIndex)
   elseif C_Spell and C_Spell.GetSpellEmpowerStageDuration and spellID then
     return C_Spell.GetSpellEmpowerStageDuration(spellID, stageIndex)
+  elseif C_CastingInfo and C_CastingInfo.GetEmpowerStageDuration then
+    return C_CastingInfo.GetEmpowerStageDuration(unit, stageIndex)
   end
 end
 
@@ -67,10 +67,10 @@ local function buildTicks()
   local numStages
   -- Attempt to use newer API providing full empower info
   local info
-  if C_CastingInfo and C_CastingInfo.GetSpellEmpowerInfo and spellID then
-    info = C_CastingInfo.GetSpellEmpowerInfo(spellID)
-  elseif C_Spell and C_Spell.GetSpellEmpowerInfo and spellID then
+  if C_Spell and C_Spell.GetSpellEmpowerInfo and spellID then
     info = C_Spell.GetSpellEmpowerInfo(spellID)
+  elseif C_CastingInfo and C_CastingInfo.GetSpellEmpowerInfo and spellID then
+    info = C_CastingInfo.GetSpellEmpowerInfo(spellID)
   end
   if info and info.numStages and info.numStages > 0 then
     numStages = info.numStages

--- a/AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua
+++ b/AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua
@@ -4,6 +4,7 @@ local wipe = wipe;
 local GetTime = GetTime;
 local GetNetStats = GetNetStats;
 local C_CastingInfo = C_CastingInfo;
+local C_Spell = C_Spell;
 
 -- Several casting APIs moved under C_CastingInfo in 11.x; provide wrappers
 local UnitCastingInfo = UnitCastingInfo or function(unit)
@@ -132,10 +133,10 @@ local function BuildStageTicks(self)
 
        -- Prefer API that returns all stage data at once
        local info
-       if C_CastingInfo and C_CastingInfo.GetSpellEmpowerInfo then
-               info = C_CastingInfo.GetSpellEmpowerInfo(self.empSpellID)
-       elseif C_Spell and C_Spell.GetSpellEmpowerInfo then
+       if C_Spell and C_Spell.GetSpellEmpowerInfo then
                info = C_Spell.GetSpellEmpowerInfo(self.empSpellID)
+       elseif C_CastingInfo and C_CastingInfo.GetSpellEmpowerInfo then
+               info = C_CastingInfo.GetSpellEmpowerInfo(self.empSpellID)
        end
        if info and info.numStages and info.numStages > 0 then
                numStages = info.numStages


### PR DESCRIPTION
## Summary
- prioritize `C_Spell` APIs when reading empower stage data
- fall back to `C_CastingInfo` or unit APIs when necessary

## Testing
- `luac -p AzCastBar/EmpowerCastBar.lua`
- `luac -p AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b36f982f7c832eb618e2e4027febd9