### PR TITLE
Align empower stage tick marks with stage boundaries

### DIFF
--- a/AzCastBar/EmpowerCastBar.lua
+++ b/AzCastBar/EmpowerCastBar.lua
@@ -28,7 +28,7 @@ stageText:SetText("")
 -- tick container
 EmpowerBar.ticks = {}
 local function clearTicks()
-  for _, t in ipairs(EmpowerBar.ticks) do t:Hide() end
+  for _, t in pairs(EmpowerBar.ticks) do t:Hide() end
   wipe(EmpowerBar.ticks)
 end
 
@@ -109,13 +109,15 @@ local function buildTicks()
   local acc = 0
   for i = 1, numStages - 1 do
     acc = acc + stageDur[i]
-    local tick = EmpowerBar:CreateTexture(nil, "OVERLAY")
-    tick:SetColorTexture(1, 1, 1, 0.6)
-    tick:SetSize(2, EmpowerBar:GetHeight())
-    local x = (acc / totalDur) * EmpowerBar:GetWidth()
-    tick:SetPoint("LEFT", EmpowerBar, "LEFT", x - 1, 0)
-    tick:Show()
-    table.insert(EmpowerBar.ticks, tick)
+    local pos = acc / totalDur
+    if pos > 0 and pos < 1 then
+      local tick = EmpowerBar:CreateTexture(nil, "OVERLAY")
+      tick:SetColorTexture(1, 1, 1, 0.6)
+      tick:SetSize(2, EmpowerBar:GetHeight())
+      tick:SetPoint("LEFT", EmpowerBar, "LEFT", pos * EmpowerBar:GetWidth() - 1, 0)
+      tick:Show()
+      table.insert(EmpowerBar.ticks, tick)
+    end
   end
 end
 

--- a/AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua
+++ b/AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua
@@ -121,7 +121,7 @@ end
 -- Empower stage tick marks
 local function ClearStageTicks(self)
        if not self.stageTicks then return end
-       for _, t in ipairs(self.stageTicks) do t:Hide() end
+       for _, t in pairs(self.stageTicks) do t:Hide() end
        wipe(self.stageTicks)
 end
 
@@ -174,20 +174,24 @@ local function BuildStageTicks(self)
        end
 
        self.stageTicks = self.stageTicks or {}
-       local acc = 0
+       local acc, tickIndex = 0, 1
        for idx = 1, numStages - 1 do
                acc = acc + durations[idx]
-               local x = (acc / total) * self.status:GetWidth()
-               local tick = self.stageTicks[idx]
-               if not tick then
-                       tick = self.status:CreateTexture(nil, "OVERLAY")
-                       tick:SetColorTexture(1, 1, 1, 0.6)
-                       self.stageTicks[idx] = tick
+               local pos = acc / total
+               if pos > 0 and pos < 1 then
+                       local x = pos * self.status:GetWidth()
+                       local tick = self.stageTicks[tickIndex]
+                       if not tick then
+                               tick = self.status:CreateTexture(nil, "OVERLAY")
+                               tick:SetColorTexture(1, 1, 1, 0.6)
+                               self.stageTicks[tickIndex] = tick
+                       end
+                       tick:ClearAllPoints()
+                       tick:SetSize(2, self.status:GetHeight())
+                       tick:SetPoint("LEFT", self.status, "LEFT", x - 1, 0)
+                       tick:Show()
+                       tickIndex = tickIndex + 1
                end
-               tick:ClearAllPoints()
-               tick:SetSize(2, self.status:GetHeight())
-               tick:SetPoint("LEFT", self.status, "LEFT", x - 1, 0)
-               tick:Show()
        end
 end
 


### PR DESCRIPTION
## Summary
- Avoid stage ticks at positions 0 or 1 by skipping zero-duration and last stages
- Clear and rebuild stage ticks safely for empowered casts

## Testing
- `luac -p AzCastBar/EmpowerCastBar.lua`
- `luac -p AzCastBar/Modules/acb_CastBar/acbCast_TWW.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b373270688832e91d39a757f0644b2